### PR TITLE
Removed full path comments on configfile

### DIFF
--- a/templates/etc/KeyTable.erb
+++ b/templates/etc/KeyTable.erb
@@ -1,5 +1,4 @@
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 
 <% @keys.each do |mykey| -%>
 <%= mykey['selector'] %>._domainkey.<%= mykey['domain'] %> <%= mykey['domain'] %>:<%= mykey['selector'] %>:<%= @configdir %>/keys/<%= mykey['domain'] %>/<%= mykey['selector'] %>

--- a/templates/etc/SigningTable.erb
+++ b/templates/etc/SigningTable.erb
@@ -1,5 +1,4 @@
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 
 <% @keys.each do |mykey| -%>
 <% mykey['signingdomains'].each do |signingdomain| -%>

--- a/templates/etc/TrustedHosts.erb
+++ b/templates/etc/TrustedHosts.erb
@@ -1,5 +1,4 @@
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 
 # To use this file, uncomment the #ExternalIgnoreList and/or the #InternalHosts
 # option in /etc/opendkim.conf then restart OpenDKIM. Additional hosts

--- a/templates/etc/opendkim.conf.erb
+++ b/templates/etc/opendkim.conf.erb
@@ -1,5 +1,4 @@
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 
 # Specifies the path to the process ID file.
 PidFile <%= @pidfile %>

--- a/templates/sysconfig/opendkim.erb
+++ b/templates/sysconfig/opendkim.erb
@@ -1,5 +1,4 @@
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 
 #ALL IS MANAGED BY init.d script and <%= @configfile %>
 


### PR DESCRIPTION
Everytime I used an other puppet environment, the file path will be changed and puppet replaces the file and restart the service.