### PR TITLE
Adding nameserver config paramter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 pkg
 pkg/
 .bundle/
+.idea/
+*.iml

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@ class opendkim(
   String                    $subdomains         = $opendkim::params::subdomains,
   String                    $socket             = $opendkim::params::socket,
   String                    $umask              = $opendkim::params::umask,
+  String                    $nameservers        = $opendkim::params::nameservers,
   Array[String]             $trusted_hosts      = $opendkim::params::trusted_hosts,
 
   Array[Struct[{

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class opendkim::params {
   $trusted_hosts = ['::1', '127.0.0.1', 'localhost']
 
   $keys = []
+  $nameservers       = undef
 
   $service_enable    = true
   $service_ensure    = 'running'

--- a/templates/etc/opendkim.conf.erb
+++ b/templates/etc/opendkim.conf.erb
@@ -77,3 +77,6 @@ OversignHeaders         From
 
 SubDomains             <%= @subdomains %>
 
+<% if @nameservers -%>
+Nameservers            <%= @nameservers %>
+<% end -%>


### PR DESCRIPTION
On ubuntu, verify DKIM key doesn't work with this puppet module (maybe you have to compare the default config agist yours) because there are some dns issues.

I have so manually confiure the nameservers in opendkim.conf to get a working opendkim setup.