### PR TITLE
if you default it to undef in params, you need to make it Optional to acce…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class opendkim(
   String                    $subdomains         = $opendkim::params::subdomains,
   String                    $socket             = $opendkim::params::socket,
   String                    $umask              = $opendkim::params::umask,
-  String                    $nameservers        = $opendkim::params::nameservers,
+  Optional[String]          $nameservers        = $opendkim::params::nameservers,
   Array[String]             $trusted_hosts      = $opendkim::params::trusted_hosts,
 
   Array[Struct[{


### PR DESCRIPTION
if you default it to undef in params, you need to make it Optional to accept undef

fixed this error the previous pull request caused

Class[Opendkim]: parameter 'nameservers' expects a String value, got Undef