### PR TITLE
Add support for MaximumSignedBytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ configuration file.
 ##### `mode`
 ##### `canonicalization`
 ##### `removeoldsignatures`
+##### `maximum_signed_bytes`
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,26 +4,27 @@
 #
 #Please see the README.md
 class opendkim(
-  String                    $user               = $opendkim::params::user,
-  String                    $group              = $opendkim::params::group,
-  Integer[-1]               $uid                = $opendkim::params::uid,
-  Integer[-1]               $gid                = $opendkim::params::gid,
+  String                    $user                 = $opendkim::params::user,
+  String                    $group                = $opendkim::params::group,
+  Integer[-1]               $uid                  = $opendkim::params::uid,
+  Integer[-1]               $gid                  = $opendkim::params::gid,
 
-  Stdlib::Absolutepath      $homedir            = $opendkim::params::homedir,
-  Stdlib::Absolutepath      $configdir          = $opendkim::params::configdir,
-  Stdlib::Absolutepath      $configfile         = $opendkim::params::configfile,
-  Stdlib::Absolutepath      $pidfile            = $opendkim::params::pidfile,
-  Stdlib::Absolutepath      $sysconfigfile      = $opendkim::params::sysconfigfile,
-  String                    $package_name       = $opendkim::params::package_name,
-  String                    $log_why            = $opendkim::params::log_why,
-  String                    $subdomains         = $opendkim::params::subdomains,
-  String                    $socket             = $opendkim::params::socket,
-  String                    $umask              = $opendkim::params::umask,
-  Optional[String]          $nameservers        = $opendkim::params::nameservers,
-  Array[String]             $trusted_hosts      = $opendkim::params::trusted_hosts,
-  String                    $mode               = $opendkim::params::mode,
-  String                    $canonicalization   = $opendkim::params::canonicalization,
-  String                    $removeoldsignatures= $opendkim::params::removeoldsignatures,
+  Stdlib::Absolutepath      $homedir              = $opendkim::params::homedir,
+  Stdlib::Absolutepath      $configdir            = $opendkim::params::configdir,
+  Stdlib::Absolutepath      $configfile           = $opendkim::params::configfile,
+  Stdlib::Absolutepath      $pidfile              = $opendkim::params::pidfile,
+  Stdlib::Absolutepath      $sysconfigfile        = $opendkim::params::sysconfigfile,
+  String                    $package_name         = $opendkim::params::package_name,
+  String                    $log_why              = $opendkim::params::log_why,
+  String                    $subdomains           = $opendkim::params::subdomains,
+  String                    $socket               = $opendkim::params::socket,
+  String                    $umask                = $opendkim::params::umask,
+  Optional[String]          $nameservers          = $opendkim::params::nameservers,
+  Array[String]             $trusted_hosts        = $opendkim::params::trusted_hosts,
+  String                    $mode                 = $opendkim::params::mode,
+  String                    $canonicalization     = $opendkim::params::canonicalization,
+  String                    $removeoldsignatures  = $opendkim::params::removeoldsignatures,
+  Optional[Integer]         $maximum_signed_bytes = $opendkim::params::maximum_signed_bytes,
 
   Array[Struct[{
     domain         => String,
@@ -31,11 +32,11 @@ class opendkim(
     publickey      => String,
     privatekey     => String,
     signingdomains => Array[String],
-  }]]                       $keys               = $opendkim::params::keys,
+  }]]                       $keys                 = $opendkim::params::keys,
 
-  Enum['running','stopped'] $service_ensure     = $opendkim::params::service_ensure,
-  Boolean                   $service_enable     = $opendkim::params::service_enable,
-  String                    $service_name       = $opendkim::params::service_name,
+  Enum['running','stopped'] $service_ensure       = $opendkim::params::service_ensure,
+  Boolean                   $service_enable       = $opendkim::params::service_enable,
+  String                    $service_name         = $opendkim::params::service_name,
 ) inherits opendkim::params {
 
   anchor { 'opendkim::begin': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class opendkim::params {
   $socket = 'inet:8891@127.0.0.1'
   $umask = '0022'
   $trusted_hosts = ['::1', '127.0.0.1', 'localhost']
+  $maximum_signed_bytes = undef
 
   $keys = []
   $nameservers       = undef

--- a/templates/etc/opendkim.conf.erb
+++ b/templates/etc/opendkim.conf.erb
@@ -83,3 +83,13 @@ Nameservers            <%= @nameservers %>
 
 # Removes all existing signatures when operating in signing mode.
 RemoveOldSignatures    <%= @removeoldsignatures %>
+
+<% if @maximum_signed_bytes -%>
+##  MaximumSignedBytes n
+##
+##  Don't sign more than "n" bytes of the message.  The default is to
+##  sign the entire message.  Setting this implies "BodyLengths".
+
+MaximumSignedBytes <%= @maximum_signed_bytes %>
+<% end -%>
+


### PR DESCRIPTION
This adds support for the _MaximumSignedBytes (integer)_ parameter stored in **/etc/opendkim.conf**