### PR TITLE
Fix duplicate resource if multiple keys are added for a domain

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -93,13 +93,13 @@ class opendkim::config inherits opendkim {
   }
 
   $opendkim::keys.each |Hash $key| {
-    file { "${opendkim::configdir}/keys/${key['domain']}":
+    ensure_resource('file', "${opendkim::configdir}/keys/${key['domain']}", {
       ensure  => 'directory',
       recurse => true,
       owner   => $opendkim::user,
       group   => $opendkim::group,
       mode    => '0600',
-    }
+    })
 
 
     file { "${opendkim::configdir}/keys/${key['domain']}/${key['selector']}":


### PR DESCRIPTION
If you have multiple keys set for a domain, the `file` resource to create the domain folder is duplicated. Using `stdlib` ensure resource resolves the issue.