### PR TITLE
Test bumping version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -44,13 +44,13 @@
     "dependencies": [
         {
             "name": "puppetlabs/stdlib",
-            "version_requirement": ">= 4.13.0 < 5.0.0"
+            "version_requirement": ">= 4.13.0 < 7.0.0"
         }
     ],
     "requirements": [
         {
             "name": "puppet",
-            "version_requirement": ">= 4.8.0 < 5.0.0"
+            "version_requirement": ">= 4.8.0 < 7.0.0"
         }
     ]
 }


### PR DESCRIPTION
It works well for me on Debian 9 and puppet 5, but obviously it would be a good idea if more people can test and confirm before merging.