### PR TITLE
Allow handling of private keys outsite puppet

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -101,13 +101,14 @@ class opendkim::config inherits opendkim {
       mode    => '0600',
     }
 
-
-    file { "${opendkim::configdir}/keys/${key['domain']}/${key['selector']}":
-      ensure  => 'file',
-      content => $key['privatekey'],
-      owner   => $opendkim::user,
-      group   => $opendkim::group,
-      mode    => '0600',
+    if($opendkim::manage_private_keys == true) {
+      file { "${opendkim::configdir}/keys/${key['domain']}/${key['selector']}":
+        ensure  => 'file',
+        content => $key['privatekey'],
+        owner   => $opendkim::user,
+        group   => $opendkim::group,
+        mode    => '0600',
+      }
     }
 
     $selector = $key['selector']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@ class opendkim(
   String                    $canonicalization     = $opendkim::params::canonicalization,
   String                    $removeoldsignatures  = $opendkim::params::removeoldsignatures,
   Optional[Integer]         $maximum_signed_bytes = $opendkim::params::maximum_signed_bytes,
+  Boolean                   $manage_private_keys  = $opendkim::params::manage_private_keys,
 
   Array[Struct[{
     domain         => String,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class opendkim::params {
   $umask = '0022'
   $trusted_hosts = ['::1', '127.0.0.1', 'localhost']
   $maximum_signed_bytes = undef
+  $manage_private_keys = true
 
   $keys = []
   $nameservers       = undef

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,7 @@
     "dependencies": [
         {
             "name": "puppetlabs/stdlib",
-            "version_requirement": ">= 4.13.0 < 5.0.0"
+            "version_requirement": ">= 4.13.0 < 7.0.0"
         }
     ],
     "requirements": [


### PR DESCRIPTION
This is meant to allow people/organizations that don't wish to have private keys in puppet to do that and still use this module.

This also bumps the stdlib requirement to allow the latest version (6.0.0).