### PR TITLE
add ability to validate dnssec

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ configuration file.
 ##### `canonicalization`
 ##### `removeoldsignatures`
 ##### `maximum_signed_bytes`
+##### `trustanchorfile`
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@ class opendkim(
   String                    $canonicalization     = $opendkim::params::canonicalization,
   String                    $removeoldsignatures  = $opendkim::params::removeoldsignatures,
   Optional[Integer]         $maximum_signed_bytes = $opendkim::params::maximum_signed_bytes,
+  String                    $trustanchorfile      = $opendkim::params::trustanchorfile,
 
   Array[Struct[{
     domain         => String,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,8 +36,7 @@ class opendkim::params {
     }
     'Redhat': {
       $sysconfigfile    = '/etc/sysconfig/opendkim'
-      $configdir        = '/etc/opendkim'
-      
+      $configdir        = '/etc/opendkim' 
     }
     default: {
       fail("${::operatingsystem} is not supported by this module.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,8 @@ class opendkim::params {
   $umask = '0022'
   $trusted_hosts = ['::1', '127.0.0.1', 'localhost']
   $maximum_signed_bytes = undef
+  $trustanchorfile  = undef
+
 
   $keys = []
   $nameservers       = undef
@@ -36,6 +38,7 @@ class opendkim::params {
     'Redhat': {
       $sysconfigfile    = '/etc/sysconfig/opendkim'
       $configdir        = '/etc/opendkim'
+      
     }
     default: {
       fail("${::operatingsystem} is not supported by this module.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,7 @@ class opendkim::params {
     }
     'Redhat': {
       $sysconfigfile    = '/etc/sysconfig/opendkim'
-      $configdir        = '/etc/opendkim' 
+      $configdir        = '/etc/opendkim'
     }
     default: {
       fail("${::operatingsystem} is not supported by this module.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,6 @@ class opendkim::params {
   $maximum_signed_bytes = undef
   $trustanchorfile  = undef
 
-
   $keys = []
   $nameservers       = undef
 

--- a/templates/etc/opendkim.conf.erb
+++ b/templates/etc/opendkim.conf.erb
@@ -93,3 +93,6 @@ RemoveOldSignatures    <%= @removeoldsignatures %>
 MaximumSignedBytes <%= @maximum_signed_bytes %>
 <% end -%>
 
+<% if @trustanchorfile -%>
+TrustAnchorFile         <%= @trustanchorfile %>
+<% end -%>


### PR DESCRIPTION
This pull requests adds the attribute TrustAnchorFile. It's needed to resolv the DKIM TXT records securely with dnssec validation.
The attribute will be only set if it's defined. The value of the attribute depends on the used resolver and os.