### PR TITLE
Add management of /etc/tmpfiles.d/opendkim.conf for RedHat

### DIFF
--- a/files/tmpfiles.d/opendkim.conf
+++ b/files/tmpfiles.d/opendkim.conf
@@ -1,0 +1,2 @@
+# Managed by Puppet
+D /var/run/opendkim 0755 opendkim opendkim -

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -83,6 +83,16 @@ class opendkim::config inherits opendkim {
     content => template('opendkim/etc/opendkim.conf.erb'),
   }
 
+  if $::osfamily == 'RedHat' {
+    file {'/etc/tmpfiles.d/opendkim.conf':
+      ensure  => present,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      source  => 'puppet:///modules/opendkim/tmpfiles.d/opendkim.conf',
+    }
+  }
+
   file { 'opendkim-TrustedHosts':
     ensure  => 'file',
     path    => "${opendkim::configdir}/TrustedHosts",


### PR DESCRIPTION
This change is mitigation to this bug, https://bugzilla.redhat.com/show_bug.cgi?id=1744391, but likely a good idea to manage this config file as well.