### PR TITLE
Allow private keys to be Deferred for use with node_encrypt

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,7 @@ class opendkim(
     domain         => String,
     selector       => String,
     publickey      => String,
-    privatekey     => String,
+    privatekey     => Variant[String,Deferred],
     signingdomains => Array[String],
   }]]                       $keys                 = $opendkim::params::keys,
 


### PR DESCRIPTION
Allowing the private key to be of type Deferred in addition to String permits it to be protected with the node_encrypt module:
https://forge.puppet.com/modules/binford2k/node_encrypt