### PR TITLE
Adds Parameters to support 2048 bit keys and Specifying hash_algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ opendkim::trusted_hosts:
 opendkim::keys:
     - domain: mydomain.com
       selector: default
+      hash_algorithms: "sha1256"
       publickey: "p=yourPublicKey"
+      publickeyextended: "secondLineofPublicKey"
       privatekey: | 
         -----BEGIN RSA PRIVATE KEY-----
         Your Private Key

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -117,6 +117,8 @@ class opendkim::config inherits opendkim {
     $selector = $opendkim::selector
     $domain = 'all'
     $publickey = $opendkim::publickey
+    $publickeyextended = $opendkim::publickeyextended
+    $hash_algorithms = $opendkim::hash_algorithms
 
     file { "${opendkim::configdir}/keys/${opendkim::selector}.txt":
       ensure  => 'file',
@@ -168,6 +170,8 @@ class opendkim::config inherits opendkim {
       $selector = $key['selector']
       $domain = $key['domain']
       $publickey = $key['publickey']
+      $publickeyextended = $key['publickeyextended']
+      $hash_algorithms = $key['hash_algorithms']
 
       file { "${opendkim::configdir}/keys/${key['domain']}/${key['selector']}.txt":
         ensure  => 'file',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -170,8 +170,14 @@ class opendkim::config inherits opendkim {
       $selector = $key['selector']
       $domain = $key['domain']
       $publickey = $key['publickey']
-      $publickeyextended = $key['publickeyextended']
-      $hash_algorithms = $key['hash_algorithms']
+
+      if ($key['publickeyextended']) {
+        $publickeyextended = $key['publickeyextended']
+      }
+
+      if ($key['hash_algorithms']) {
+        $hash_algorithms = $key['hash_algorithms']
+      }
 
       file { "${opendkim::configdir}/keys/${key['domain']}/${key['selector']}.txt":
         ensure  => 'file',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -117,8 +117,14 @@ class opendkim::config inherits opendkim {
     $selector = $opendkim::selector
     $domain = 'all'
     $publickey = $opendkim::publickey
-    $publickeyextended = $opendkim::publickeyextended
-    $hash_algorithms = $opendkim::hash_algorithms
+
+    if ($opendkim::publickeyextended) {
+      $publickeyextended = $opendkim::publickeyextended
+    }
+
+    if ($opendkim::hash_algorithms) {
+      $hash_algorithms = $opendkim::hash_algorithms
+    }
 
     file { "${opendkim::configdir}/keys/${opendkim::selector}.txt":
       ensure  => 'file',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class opendkim(
   Boolean                   $alldomain            = $opendkim::params::alldomain,
   Optional[String]          $selector             = $opendkim::params::selector,
   Optional[String]          $publickey            = $opendkim::params::publickey,
+  Optional[String]          $publickeyextended    = $opendkim::params::publickeyextended,
   Optional[String]          $privatekey           = $opendkim::params::privatekey,
   Optional[String]          $signaturealgorithm   = $opendkim::params::signaturealgorithm,
   Optional[Integer]         $minimumkeybits       = $opendkim::params::minimumkeybits,
@@ -46,6 +47,8 @@ class opendkim(
   Enum['running','stopped'] $service_ensure       = $opendkim::params::service_ensure,
   Boolean                   $service_enable       = $opendkim::params::service_enable,
   String                    $service_name         = $opendkim::params::service_name,
+
+  String                    $hash_algorithms      = $opendkim::params::hash_algorithms,
 ) inherits opendkim::params {
 
   anchor { 'opendkim::begin': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,11 +38,13 @@ class opendkim(
   Optional[Integer]         $minimumkeybits       = $opendkim::params::minimumkeybits,
 
   Array[Struct[{
-    domain         => String,
-    selector       => String,
-    publickey      => String,
-    privatekey     => Variant[String,Deferred],
-    signingdomains => Array[String],
+    domain            => String,
+    selector          => String,
+    hash_algorithms   => String,
+    publickey         => String,
+    publickeyextended => String,
+    privatekey        => Variant[String,Deferred],
+    signingdomains    => Array[String],
   }]]                       $keys                 = $opendkim::params::keys,
 
   Enum['running','stopped'] $service_ensure       = $opendkim::params::service_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class opendkim(
   Optional[String]          $publickey            = $opendkim::params::publickey,
   Optional[String]          $publickeyextended    = $opendkim::params::publickeyextended,
   Optional[String]          $privatekey           = $opendkim::params::privatekey,
+  Optional[String]          $hash_algorithms      = $opendkim::params::hash_algorithms,
   Optional[String]          $signaturealgorithm   = $opendkim::params::signaturealgorithm,
   Optional[Integer]         $minimumkeybits       = $opendkim::params::minimumkeybits,
 
@@ -47,8 +48,6 @@ class opendkim(
   Enum['running','stopped'] $service_ensure       = $opendkim::params::service_ensure,
   Boolean                   $service_enable       = $opendkim::params::service_enable,
   String                    $service_name         = $opendkim::params::service_name,
-
-  String                    $hash_algorithms      = $opendkim::params::hash_algorithms,
 ) inherits opendkim::params {
 
   anchor { 'opendkim::begin': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,9 +40,9 @@ class opendkim(
   Array[Struct[{
     domain            => String,
     selector          => String,
-    hash_algorithms   => String,
+    hash_algorithms   => Optional[String],
     publickey         => String,
-    publickeyextended => String,
+    publickeyextended => Optional[String],
     privatekey        => Variant[String,Deferred],
     signingdomains    => Array[String],
   }]]                       $keys                 = $opendkim::params::keys,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,9 @@ class opendkim::params {
   $alldomain = false
   $selector = undef
   $publickey = undef
+  $publickeyextended = undef
   $privatekey = undef
+  $hash_algorithms = undef
   $signaturealgorithm = undef
   $minimumkeybits = undef
 

--- a/templates/public-rsa-key.erb
+++ b/templates/public-rsa-key.erb
@@ -1,2 +1,7 @@
-<%= @selector -%>._domainkey      IN      TXT     ( "v=DKIM1; k=rsa; "
+<%= @selector -%>._domainkey      IN      TXT     ( "v=DKIM1; <% if @hash_algorithms -%>h=<%= @hash_algorithms -%>; <% end -%>k=rsa; "
+       <% if @publickey and @publickeyextended -%>
+         "<%= @publickey -%>"
+         "<%= @publickeyextended -%>" )  ; ----- DKIM key <%= @selector -%> for <%= @domain -%>
+       <% else -%>
          "<%= @publickey -%>" )  ; ----- DKIM key <%= @selector -%> for <%= @domain -%>
+       <% end -%>


### PR DESCRIPTION
Adds parameters for supporting multi-line bit keys.  For example, a 2048 bit DKIM key is structurally different than the default 1024.  Changes add a parameter called "publickeyextended" where you specify the second line.  Also adds parameter called "hash_algrothems" which allows you to specify what hash type the DKIM key uses.  For example, when creating a key that is using sha256, the DKIM record will contain the hash parameter (ie h=sha256).  This will help when migrating from an older hash, ie SHA1 to the more standard SHA256.  Both parameters are optional.