### PR TITLE
Fix remaining legacy facts

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class opendkim::config inherits opendkim {
     }
   }
 
-  if $::osfamily == 'FreeBSD' {
+  if fact('os.family') == 'FreeBSD' {
     file_line {
       default:
         path => '/etc/rc.conf',
@@ -83,7 +83,7 @@ class opendkim::config inherits opendkim {
     content => template('opendkim/etc/opendkim.conf.erb'),
   }
 
-  if $::osfamily == 'RedHat' {
+  if fact('os.family') == 'RedHat' {
     file {'/etc/tmpfiles.d/opendkim.conf':
       ensure  => present,
       owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,10 +53,10 @@ class opendkim(
 ) inherits opendkim::params {
 
   anchor { 'opendkim::begin': }
-  -> class { '::opendkim::user': }
-  -> class { '::opendkim::install': }
-  -> class { '::opendkim::config': }
-  ~> class { '::opendkim::service': }
+  -> class { 'opendkim::user': }
+  -> class { 'opendkim::install': }
+  -> class { 'opendkim::config': }
+  ~> class { 'opendkim::service': }
   -> anchor { 'opendkim::end': }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,7 @@ class opendkim::install inherits opendkim {
 
   package { 'opendkim':
     ensure => installed,
-    name   => $::opendkim::package_name,
+    name   => $opendkim::package_name,
   }
 
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -12,7 +12,7 @@ class opendkim::user inherits opendkim {
     }
   }
 
-  $shelluser = $::osfamily ? {
+  $shelluser = fact('os.family') ? {
     'RedHat' => '/sbin/nologin',
     default  => '/usr/sbin/nologin',
   }


### PR DESCRIPTION
Now that we can remove legacy facts from Puppet (`puppet config set
include_legacy_facts false`) we can use this to ensure the module behave
as expected.

While here, also remove artifacts from the Puppet 3.x era.
