### PR TITLE
Fix default value for sysconfigfile

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,7 +107,7 @@ class opendkim (
   Stdlib::Absolutepath            $configfile           = '/etc/opendkim.conf',
   Stdlib::Absolutepath            $pidfile              = '/run/opendkim/opendkim.pid',
   Pattern[/\A[0-7]{3,4}\z/]       $rundir_mode          = '0755',
-  Optional[Stdlib::Absolutepath]  $sysconfigfile        = '/etc/sysconfig/opendkim', # lint:ignore:optional_default
+  Optional[Stdlib::Absolutepath]  $sysconfigfile        = undef,
   String[1]                       $package_name         = 'opendkim',
   String[1]                       $service_name         = 'opendkim',
   Stdlib::Ensure::Service         $service_ensure       = 'running',


### PR DESCRIPTION
An optional parameter cannot have non-undef default value because.  This is detected by puppet-lint, but the check was incorrectly disabled on this line.

This prevent the creation of this file on systems where it is not used, e.g. FreeBSD.