### PR TITLE
RHEL 7 no longer supported

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -20,7 +19,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]


### PR DESCRIPTION
9d582fac6cfae9a9ba91f85771157c55a59d78a4 breaks support for RHEL 7 as `RuntimeDirectory` is not supported in that version of systemd.