### PR TITLE
Lookup osfamily for RedHat clones

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -10,5 +10,7 @@ hierarchy:
     path: '%{facts.os.name}.yaml'
   - name: 'OS Family Major Version'
     path: '%{facts.os.family}-%{facts.os.release.major}.yaml'
+  - name: 'OS Family'
+    path: '%{facts.os.family}.yaml'
   - name: 'common'
     path: 'common.yaml'


### PR DESCRIPTION
In #35 OS specific config was moved  to hiera.

However, the configured hierarchy only looks up the OS by facts.os.name which means RedHat.yaml doesn't apply settings to RHEL clones e.g. CentOS, Rocky, Alma.

This is currently preventing the sysconfig file being configured on these systems and the wrong path is being used for the opendkim users shell.

This PR adds a facts.os.family lookup to the hierarchy so all RedHat family OS' get the settings from RedHat.yaml