### PR TITLE
Missing Optional for autorestart

### DIFF
--- a/templates/etc/opendkim.conf.epp
+++ b/templates/etc/opendkim.conf.epp
@@ -18,7 +18,7 @@
       Optional[String[1]] $signaturealgorithm,
       Optional[Integer[1]] $minimumkeybits,
       Hash[String,Variant[Array[String],String,Integer,Boolean]] $additional_options,
-      Variant[Boolean,Enum['yes','no']] $autorestart,
+      Optional[Variant[Boolean,Enum['yes','no']]] $autorestart,
       Optional[Pattern[/\A[0-9]+\/[0-9]+[sSmMhHdD]\z/]] $autorestartrate
 | -%>
 # THIS FILE IS MANAGED BY PUPPET


### PR DESCRIPTION
The autorestart config introduced in #42 throws the below error if the autorestart parameter isn't passed to the opendkim module:

`Error while evaluating a Function Call, lambda: parameter 'autorestart' expects a value of type Boolean or Enum, got Undef`

There is already logic in the template to ignore autorestart if it is undef. It's just a validation issue on the template parameter - which this PR corrects.