### PR TITLE
Add SignHeaders From

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,0 @@
-require 'puppet-lint'
-
-PuppetLint::Plugins.load_spec_helpe

--- a/templates/etc/opendkim.conf.epp
+++ b/templates/etc/opendkim.conf.epp
@@ -125,6 +125,7 @@ InternalHosts           refile:<%= $configdir %>/TrustedHosts
 # and the verifier.  From is oversigned by default in the Debian pacakge
 # because it is often the identity key used by reputation systems and thus
 # somewhat security sensitive.
+SignHeaders		From
 OversignHeaders         From
 
 SubDomains             <%= $subdomains ? { true => 'yes', false => 'no', default => $subdomains } %>


### PR DESCRIPTION
From the man opendkim.conf:
   OversignHeaders (dataset)
      Specifies  a  set of header fields that should be included
      in all signature header lists (the "h=" tag) once more than
      the number of times they were actually present in the signed
      message.  The set  is  empty  by  default.
      The purpose of this, and especially of listing an absent
      header field, is to prevent the addition of important fields
      between the signer and the verifier.  Since the verifier would
      include  that  header  field when  performing  verification
      if it had been added by an intermediary, the signed message
      and the verified message were different and the verification
      would fail.  Note that listing a field name here and not
      listing it in the SignHeaders list is likely to generate
      invalid signatures.