### PR TITLE
chore: update module version and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ You are pleased to fork this module and adapt it for you needs. I am open to any
 
 ## Release Notes/Contributors/Etc
 
+### v0.4 - Compatible with Puppet from 6.24 up to, but not including, 8.0
+
+* v0.4.1  Fix version in metadata.json
+* v0.4.0  Add autorestart config
+          Lookup for OS Family facts in Hiera
+          Use var opendkim::user as the owner of files
+          Fix: Set default value for var opendkim::sysconfigfile
+          Set show_diff to false for all private key resources
+
 ### v0.3 - Compatible with Puppet from 6.4 to newer
 
 * v0.3.0 Correct a bug about an optional parameter

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lvicainne-opendkim",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "author": "lvicainne,cruelsmith",
   "license": "Apache-2.0",
   "summary": "Manage an OpenDKIM configuration",


### PR DESCRIPTION
This Pull Requests will fix the issue where the version information of puppet-opendkim module on Puppet forge is not up to date with the releases on GitHub.

Fix:
- https://github.com/lvicainne/puppet-opendkim/issues/52