### PR TITLE
add Ubuntu 24.04 , drop Ubuntu 18.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -41,9 +41,9 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     },
     {


### PR DESCRIPTION
Hi,

Ubuntu 24.04 is tested in my private CI pipeline with OpenDKIM and Postfix.

The following Beaker acceptances tests are done about OpenDKIM integration with Postfix.
And tests passed with Ubuntu24.04,  lvicainne-opendkim 0.4.3, puppet-postfix 5.0.0 :

```
    describe command('postconf -n') do
      its(:stdout) { is_expected.not_to match %r{relay_domains} }
      its(:stdout) { is_expected.to match %r{smtpd_milters = inet:127.0.0.1:8891} }
      its(:stdout) { is_expected.to match %r{non_smtpd_milters = inet:127.0.0.1:8891} }
    end

    describe package('opendkim') do
      it { is_expected.to be_installed }
    end

    describe service('opendkim') do
      it { is_expected.to be_enabled }
      it { is_expected.to be_running }
    end

    describe port(8891) do
      it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
    end

    describe file('/etc/opendkim/keys/smtpd-server.example.com/gitlabci') do
      it { is_expected.to be_owned_by 'opendkim' }
      it { is_expected.to be_grouped_into 'opendkim' }
      it { is_expected.to be_mode 600 }
      its(:content) { is_expected.to match %r{-----BEGIN PRIVATE KEY-----} }
    end

    # Checks that mail from signingdomains are signed by opendkim
    describe command("echo '#{mail_message}' | mail -r root@#{fqdn_server} -s 'A: true smtpd-server dkim signed message' #{receiver_mail_address}") do
      its(:exit_status) { is_expected.to eq 0 }
    end
    describe command('journalctl --no-pager') do
      its(:stdout) { is_expected.to match %r{.*opendkim.*DKIM-Signature field added.*} }
    end
```